### PR TITLE
define export in both services

### DIFF
--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -20,6 +20,12 @@ services:
             # You have to adapt the local path you want the consumption
             # directory to mount to by modifying the part before the ':'.
             - ./consume:/consume
+						# Likewise, you can add a local path to mount a directory for
+            # exporting. This is not strictly needed for paperless to
+            # function, only if you're exporting your files: uncomment
+            # it and fill in a local path if you know you're going to
+            # want to export your documents.
+            # - /path/to/another/arbitrary/place:/export
         env_file: docker-compose.env
         # The reason the line is here is so that the webserver that doesn't do
         # any text recognition and doesn't have to install unnecessary


### PR DESCRIPTION
If export isn't defined in both services, docker creates a volume for it under webserver.
Adding export under both consolidates the volumes and stops docker from creating a second export volume.