### PR TITLE
Update README.md to add a reference to paperless-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Paperless has been around a while now, and people are starting to build stuff on
 
 * [Paperless Desktop](https://github.com/thomasbrueggemann/paperless-desktop): A desktop UI for your Paperless installation.  Runs on Mac, Linux, and Windows.
 * [ansible-role-paperless](https://github.com/ovv/ansible-role-paperless): An easy way to get Paperless running via Ansible.
-
+* [paperless-cli](https://github.com/stgarf/paperless-cli): A golang command line binary to interact with a Paperless instance.
 
 ## Similar Projects
 


### PR DESCRIPTION
[paperless-cli](http://github.com/stgarf/paperless-cli) is a golang command line binary to interact with a Paperless instance.

So far it does {list,search} for {tags, correspondents, documents}.

I'll be working on it over time to add features such as fetching the actual PDF and editing {tags, correspondents, documents} from the command line.

Also, can someone write the German and Greek translations if you end up merging this?