### PR TITLE
Warn if consume directory contains subdirectories

### DIFF
--- a/src/documents/consumer.py
+++ b/src/documents/consumer.py
@@ -94,6 +94,11 @@ class Consumer:
                     ignored_files.append(file)
                 else:
                     files.append(file)
+            else:
+                self.logger.warning(
+                    "Skipping %s as it is not a file",
+                    entry.path
+                )
 
         if not files:
             return

--- a/src/documents/management/commands/document_consumer.py
+++ b/src/documents/management/commands/document_consumer.py
@@ -26,6 +26,7 @@ class Command(BaseCommand):
     def __init__(self, *args, **kwargs):
 
         self.verbosity = 0
+        self.logger = logging.getLogger(__name__)
 
         self.file_consumer = None
         self.mail_fetcher = None
@@ -138,6 +139,11 @@ class Command(BaseCommand):
                         file = os.path.join(directory, event.name)
                         if os.path.isfile(file):
                             self.file_consumer.try_consume_file(file)
+                        else:
+                            self.logger.warning(
+                                "Skipping %s as it is not a file",
+                                file
+                            )
                 else:
                     break
 


### PR DESCRIPTION
Currently, the consumer ignores files in subdirectories of the consume directory.

This changes the behaviour to find files recursively instead.

While switching to Paperless, I copied my old directory structure with subdirectories for each year into the consume directory. The consumer didn't pick up anything which got me a bit confused.