### PR TITLE
requirements.txt: bring back Linux-only restriction for inotify-simple

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ fuzzywuzzy[speedup]==0.15.0
 gunicorn==19.9.0
 idna==2.8
 imagesize==1.1.0
-inotify-simple==1.1.8
+inotify-simple==1.1.8; sys_platform == 'linux'
 jinja2==2.10
 langdetect==1.0.7
 markupsafe==1.1.0


### PR DESCRIPTION
Fixes #418