### PR TITLE
Serve thumbnails additionally in WebP format to improve performance

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM alpine:3.10
 
 LABEL maintainer="The Paperless Project https://github.com/the-paperless-project/paperless" \
       contributors="Guy Addadi <addadi@gmail.com>, Pit Kleyersburg <pitkley@googlemail.com>, \
@@ -21,6 +21,7 @@ RUN apk add --no-cache \
       libmagic \
       libpq \
       optipng \
+      libwebp \
       poppler \
       python3 \
       shadow \

--- a/src/documents/admin.py
+++ b/src/documents/admin.py
@@ -284,6 +284,7 @@ class DocumentAdmin(DjangoQLSearchMixin, CommonAdmin):
         html_thumb_srcset = self._html_tag(
                     "source",
                     srcset = reverse("fetch", kwargs={"kind": "thumb", "pk": obj.pk}),
+                    type = "image/png",
                     width=180,
                     alt="Thumbnail of {}".format(obj.file_name),
                     title=obj.file_name
@@ -292,6 +293,7 @@ class DocumentAdmin(DjangoQLSearchMixin, CommonAdmin):
         html_thumbwebp_srcset = self._html_tag(
                     "source",
                     srcset= reverse("fetch", kwargs={"kind": "thumbwebp", "pk": obj.pk}),
+                    type = "image/webp",
                     width=180,
                     alt="Thumbnail of {}".format(obj.file_name),
                     title=obj.file_name

--- a/src/documents/admin.py
+++ b/src/documents/admin.py
@@ -302,6 +302,7 @@ class DocumentAdmin(DjangoQLSearchMixin, CommonAdmin):
         html_thumb_imgsrc = self._html_tag(
                     "img",
                     src=reverse("fetch", kwargs={"kind": "thumb", "pk": obj.pk}),
+                    type = "image/png",
                     width=180,
                     alt="Thumbnail of {}".format(obj.file_name),
                     title=obj.file_name

--- a/src/documents/admin.py
+++ b/src/documents/admin.py
@@ -281,34 +281,32 @@ class DocumentAdmin(DjangoQLSearchMixin, CommonAdmin):
 
     @mark_safe
     def thumbnail(self, obj):
-        return self._html_tag(
-            "a",
-            self._html_tag(
-                "picture",
-                self._html_tag(
+        html_thumb_srcset = self._html_tag(
                     "source",
                     srcset = reverse("fetch", kwargs={"kind": "thumb", "pk": obj.pk}),
                     width=180,
                     alt="Thumbnail of {}".format(obj.file_name),
                     title=obj.file_name
-                ),
-                self._html_tag(
+                )
+
+        html_thumbwebp_srcset = self._html_tag(
                     "source",
                     srcset= reverse("fetch", kwargs={"kind": "thumbwebp", "pk": obj.pk}),
                     width=180,
                     alt="Thumbnail of {}".format(obj.file_name),
                     title=obj.file_name
-                ),
-                self._html_tag(
+                )
+
+        html_thumb_imgsrc = self._html_tag(
                     "img",
                     src=reverse("fetch", kwargs={"kind": "thumb", "pk": obj.pk}),
                     width=180,
                     alt="Thumbnail of {}".format(obj.file_name),
                     title=obj.file_name
                 )
-            ),
-            href=obj.download_url
-        )
+
+        return '<a href="%s"><picture>%s%s%s</picture></a>' % (obj.download_url, html_thumb_srcset, html_thumbwebp_srcset, html_thumb_imgsrc)
+
 
     @mark_safe
     def tags_(self, obj):

--- a/src/documents/admin.py
+++ b/src/documents/admin.py
@@ -305,7 +305,7 @@ class DocumentAdmin(DjangoQLSearchMixin, CommonAdmin):
                     title=obj.file_name
                 )
 
-        return '<a href="%s"><picture>%s%s%s</picture></a>' % (obj.download_url, html_thumb_srcset, html_thumbwebp_srcset, html_thumb_imgsrc)
+        return '<a href="%s"><picture>%s%s%s</picture></a>' % (obj.download_url, html_thumbwebp_srcset, html_thumb_srcset, html_thumb_imgsrc)
 
 
     @mark_safe

--- a/src/documents/admin.py
+++ b/src/documents/admin.py
@@ -282,34 +282,39 @@ class DocumentAdmin(DjangoQLSearchMixin, CommonAdmin):
     @mark_safe
     def thumbnail(self, obj):
         html_thumb_srcset = self._html_tag(
-                    "source",
-                    srcset = reverse("fetch", kwargs={"kind": "thumb", "pk": obj.pk}),
-                    type = "image/png",
-                    width=180,
-                    alt="Thumbnail of {}".format(obj.file_name),
-                    title=obj.file_name
-                )
+            "source",
+            srcset=reverse("fetch", kwargs={"kind": "thumb", "pk": obj.pk}),
+            type="image/png",
+            width=180,
+            alt="Thumbnail of {}".format(obj.file_name),
+            title=obj.file_name
+            )
 
         html_thumbwebp_srcset = self._html_tag(
-                    "source",
-                    srcset= reverse("fetch", kwargs={"kind": "thumbwebp", "pk": obj.pk}),
-                    type = "image/webp",
-                    width=180,
-                    alt="Thumbnail of {}".format(obj.file_name),
-                    title=obj.file_name
-                )
+            "source",
+            srcset=reverse("fetch", kwargs={"kind": "thumbwebp",
+                                            "pk": obj.pk}),
+            type="image/webp",
+            width=180,
+            alt="Thumbnail of {}".format(obj.file_name),
+            title=obj.file_name
+            )
 
         html_thumb_imgsrc = self._html_tag(
-                    "img",
-                    src=reverse("fetch", kwargs={"kind": "thumb", "pk": obj.pk}),
-                    type = "image/png",
-                    width=180,
-                    alt="Thumbnail of {}".format(obj.file_name),
-                    title=obj.file_name
-                )
+            "img",
+            src=reverse("fetch", kwargs={"kind": "thumb", "pk": obj.pk}),
+            type="image/png",
+            width=180,
+            alt="Thumbnail of {}".format(obj.file_name),
+            title=obj.file_name
+            )
 
-        return '<a href="%s"><picture>%s%s%s</picture></a>' % (obj.download_url, html_thumbwebp_srcset, html_thumb_srcset, html_thumb_imgsrc)
-
+        return '<a href="%s"><picture>%s%s%s</picture></a>' % (
+            obj.download_url,
+            html_thumbwebp_srcset,
+            html_thumb_srcset,
+            html_thumb_imgsrc
+            )
 
     @mark_safe
     def tags_(self, obj):

--- a/src/documents/admin.py
+++ b/src/documents/admin.py
@@ -284,11 +284,28 @@ class DocumentAdmin(DjangoQLSearchMixin, CommonAdmin):
         return self._html_tag(
             "a",
             self._html_tag(
-                "img",
-                src=reverse("fetch", kwargs={"kind": "thumb", "pk": obj.pk}),
-                width=180,
-                alt="Thumbnail of {}".format(obj.file_name),
-                title=obj.file_name
+                "picture",
+                self._html_tag(
+                    "source",
+                    srcset = reverse("fetch", kwargs={"kind": "thumb", "pk": obj.pk}),
+                    width=180,
+                    alt="Thumbnail of {}".format(obj.file_name),
+                    title=obj.file_name
+                ),
+                self._html_tag(
+                    "source",
+                    srcset= reverse("fetch", kwargs={"kind": "thumbwebp", "pk": obj.pk}),
+                    width=180,
+                    alt="Thumbnail of {}".format(obj.file_name),
+                    title=obj.file_name
+                ),
+                self._html_tag(
+                    "img",
+                    src=reverse("fetch", kwargs={"kind": "thumb", "pk": obj.pk}),
+                    width=180,
+                    alt="Thumbnail of {}".format(obj.file_name),
+                    title=obj.file_name
+                )
             ),
             href=obj.download_url
         )

--- a/src/documents/consumer.py
+++ b/src/documents/consumer.py
@@ -204,7 +204,7 @@ class Consumer:
         return sorted(
             options, key=lambda _: _["weight"], reverse=True)[0]["parser"]
 
-    def _store(self, text, doc, thumbnail, thumbnail_webp date):
+    def _store(self, text, doc, thumbnail, thumbnail_webp, date):
 
         file_info = FileInfo.from_path(doc)
 

--- a/src/documents/consumer.py
+++ b/src/documents/consumer.py
@@ -150,11 +150,13 @@ class Consumer:
 
         try:
             thumbnail = parsed_document.get_optimised_thumbnail()
+            thumbnail_webp = parsed_document.get_thumbnail_webp()
             date = parsed_document.get_date()
             document = self._store(
                 parsed_document.get_text(),
                 doc,
                 thumbnail,
+                thumbnail_webp,
                 date
             )
         except ParseError as e:
@@ -202,7 +204,7 @@ class Consumer:
         return sorted(
             options, key=lambda _: _["weight"], reverse=True)[0]["parser"]
 
-    def _store(self, text, doc, thumbnail, date):
+    def _store(self, text, doc, thumbnail, thumbnail_webp date):
 
         file_info = FileInfo.from_path(doc)
 
@@ -233,6 +235,7 @@ class Consumer:
 
         self._write(document, doc, document.source_path)
         self._write(document, thumbnail, document.thumbnail_path)
+        self._write(document, thumbnail_webp, document.thumbnail_path_webp)
 
         self.log("info", "Completed")
 

--- a/src/documents/consumer.py
+++ b/src/documents/consumer.py
@@ -235,7 +235,7 @@ class Consumer:
 
         self._write(document, doc, document.source_path)
         self._write(document, thumbnail, document.thumbnail_path)
-        self._write(document, thumbnail_webp, document.thumbnail_path_webp)
+        self._write(document, thumbnail_webp, document.thumbnail_webp_path)
 
         self.log("info", "Completed")
 

--- a/src/documents/management/commands/document_exporter.py
+++ b/src/documents/management/commands/document_exporter.py
@@ -91,9 +91,9 @@ class Command(Renderable, BaseCommand):
                     f.write(GnuPG.decrypted(document.thumbnail_file))
                     os.utime(thumbnail_target, times=(t, t))
 
-                if os.path.exists(document.thumbnail_path_webp):
+                if os.path.exists(document.thumbnail_webp_path):
                     with open(thumbnail_webp_target, "wb") as f:
-                        f.write(GnuPG.decrypted(document.thumbnail_file_webp))
+                        f.write(GnuPG.decrypted(document.thumbnail_webp_file))
                         os.utime(thumbnail_webp_target, times=(t, t))
 
             else:
@@ -101,8 +101,8 @@ class Command(Renderable, BaseCommand):
                 shutil.copy(document.source_path, file_target)
                 shutil.copy(document.thumbnail_path, thumbnail_target)
 
-                if os.path.exists(document.thumbnail_path_webp):
-                    shutil.copy(document.thumbnail_path_webp, thumbnail_webp_target)
+                if os.path.exists(document.thumbnail_webp_path):
+                    shutil.copy(document.thumbnail_webp_path, thumbnail_webp_target)
 
         manifest += json.loads(
             serializers.serialize("json", Correspondent.objects.all()))

--- a/src/documents/management/commands/document_exporter.py
+++ b/src/documents/management/commands/document_exporter.py
@@ -10,7 +10,9 @@ from documents.models import Document, Correspondent, Tag
 from paperless.db import GnuPG
 
 from ...mixins import Renderable
-from documents.settings import EXPORTER_FILE_NAME, EXPORTER_THUMBNAIL_NAME, EXPORTER_THUMBNAIL_WEBP_NAME
+from documents.settings import (EXPORTER_FILE_NAME,
+                                EXPORTER_THUMBNAIL_NAME,
+                                EXPORTER_THUMBNAIL_WEBP_NAME)
 
 
 class Command(Renderable, BaseCommand):
@@ -66,17 +68,17 @@ class Command(Renderable, BaseCommand):
 
             file_target = os.path.join(self.target, document.file_name)
 
-            thumbnail_name = document.file_name + "-thumbnail.png"
-            thumbnail_target = os.path.join(self.target, thumbnail_name)
-            
-            thumbnail_webp_name = document.file_name + "-thumbnail.webp"
-            thumbnail_webp_target = os.path.join(self.target, thumbnail_webp_name)
+            thumb_name = document.file_name + "-thumbnail.png"
+            thumb_target = os.path.join(self.target, thumb_name)
 
             document_dict[EXPORTER_FILE_NAME] = document.file_name
-            document_dict[EXPORTER_THUMBNAIL_NAME] = thumbnail_name
+            document_dict[EXPORTER_THUMBNAIL_NAME] = thumb_name
 
-            if os.path.exists(thumbnail_webp_target):
-                document_dict[EXPORTER_THUMBNAIL_WEBP_NAME] = thumbnail_webp_name
+            thumb_webp_name = document.file_name + "-thumbnail.webp"
+            thumb_webp_target = os.path.join(self.target, thumb_webp_name)
+
+            if os.path.exists(thumb_webp_target):
+                document_dict[EXPORTER_THUMBNAIL_WEBP_NAME] = thumb_webp_name
 
             print("Exporting: {}".format(file_target))
 
@@ -87,22 +89,23 @@ class Command(Renderable, BaseCommand):
                     f.write(GnuPG.decrypted(document.source_file))
                     os.utime(file_target, times=(t, t))
 
-                with open(thumbnail_target, "wb") as f:
+                with open(thumb_target, "wb") as f:
                     f.write(GnuPG.decrypted(document.thumbnail_file))
-                    os.utime(thumbnail_target, times=(t, t))
+                    os.utime(thumb_target, times=(t, t))
 
                 if os.path.exists(document.thumbnail_webp_path):
-                    with open(thumbnail_webp_target, "wb") as f:
+                    with open(thumb_webp_target, "wb") as f:
                         f.write(GnuPG.decrypted(document.thumbnail_webp_file))
-                        os.utime(thumbnail_webp_target, times=(t, t))
+                        os.utime(thumb_webp_target, times=(t, t))
 
             else:
 
                 shutil.copy(document.source_path, file_target)
-                shutil.copy(document.thumbnail_path, thumbnail_target)
+                shutil.copy(document.thumbnail_path, thumb_target)
 
                 if os.path.exists(document.thumbnail_webp_path):
-                    shutil.copy(document.thumbnail_webp_path, thumbnail_webp_target)
+                    shutil.copy(document.thumbnail_webp_path,
+                                thumb_webp_target)
 
         manifest += json.loads(
             serializers.serialize("json", Correspondent.objects.all()))

--- a/src/documents/models.py
+++ b/src/documents/models.py
@@ -295,7 +295,7 @@ class Document(models.Model):
     @property
     def thumbnail_path(self):
 
-        file_name = "{:07}.webp".format(self.pk)
+        file_name = "{:07}.png".format(self.pk)
         if self.storage_type == self.STORAGE_TYPE_GPG:
             file_name += ".gpg"
 
@@ -312,6 +312,28 @@ class Document(models.Model):
 
     @property
     def thumbnail_url(self):
+        return reverse("fetch", kwargs={"kind": "thumb", "pk": self.pk})
+
+    @property
+    def thumbnail_path_webp(self):
+
+        file_name = "{:07}.webp".format(self.pk)
+        if self.storage_type == self.STORAGE_TYPE_GPG:
+            file_name += ".gpg"
+
+        return os.path.join(
+            settings.MEDIA_ROOT,
+            "documents",
+            "thumbnails",
+            file_name
+        )
+
+    @property
+    def thumbnail_file_webp(self):
+        return open(self.thumbnail_path, "rb")
+
+    @property
+    def thumbnail_url_webp(self):
         return reverse("fetch", kwargs={"kind": "thumb", "pk": self.pk})
 
 

--- a/src/documents/models.py
+++ b/src/documents/models.py
@@ -330,11 +330,11 @@ class Document(models.Model):
 
     @property
     def thumbnail_file_webp(self):
-        return open(self.thumbnail_path, "rb")
+        return open(self.thumbnail_path_webp, "rb")
 
     @property
     def thumbnail_url_webp(self):
-        return reverse("fetch", kwargs={"kind": "thumb", "pk": self.pk})
+        return reverse("fetch", kwargs={"kind": "thumbwebp", "pk": self.pk})
 
 
 class Log(models.Model):

--- a/src/documents/models.py
+++ b/src/documents/models.py
@@ -315,7 +315,7 @@ class Document(models.Model):
         return reverse("fetch", kwargs={"kind": "thumb", "pk": self.pk})
 
     @property
-    def thumbnail_path_webp(self):
+    def thumbnail_webp_path(self):
 
         file_name = "{:07}.webp".format(self.pk)
         if self.storage_type == self.STORAGE_TYPE_GPG:
@@ -329,11 +329,11 @@ class Document(models.Model):
         )
 
     @property
-    def thumbnail_file_webp(self):
-        return open(self.thumbnail_path_webp, "rb")
+    def thumbnail_webp_file(self):
+        return open(self.thumbnail_webp_path, "rb")
 
     @property
-    def thumbnail_url_webp(self):
+    def thumbnail_webp_url(self):
         return reverse("fetch", kwargs={"kind": "thumbwebp", "pk": self.pk})
 
 

--- a/src/documents/models.py
+++ b/src/documents/models.py
@@ -295,7 +295,7 @@ class Document(models.Model):
     @property
     def thumbnail_path(self):
 
-        file_name = "{:07}.png".format(self.pk)
+        file_name = "{:07}.webp".format(self.pk)
         if self.storage_type == self.STORAGE_TYPE_GPG:
             file_name += ".gpg"
 

--- a/src/documents/parsers.py
+++ b/src/documents/parsers.py
@@ -52,13 +52,13 @@ class DocumentParser:
 
     def get_thumbnail(self):
         """
-        Returns the path to a file we can use as a thumbnail for this document.
+        Returns the png thumbnail file path for this document.
         """
         raise NotImplementedError()
 
     def get_thumbnail_webp(self):
         """
-        Returns the path to a webp file we can use as a thumbnail for this document.
+        Returns the WebP thumbnail file path for this document.
         """
         raise NotImplementedError()
 

--- a/src/documents/parsers.py
+++ b/src/documents/parsers.py
@@ -58,6 +58,8 @@ class DocumentParser:
 
     def optimise_thumbnail(self, in_path):
 
+        if not in_path.endswith(".png")
+            return in_path
         out_path = os.path.join(self.tempdir, "optipng.png")
 
         args = (self.OPTIPNG, "-o5", in_path, "-out", out_path)

--- a/src/documents/parsers.py
+++ b/src/documents/parsers.py
@@ -56,9 +56,15 @@ class DocumentParser:
         """
         raise NotImplementedError()
 
+    def get_thumbnail_webp(self):
+        """
+        Returns the path to a webp file we can use as a thumbnail for this document.
+        """
+        raise NotImplementedError()
+
     def optimise_thumbnail(self, in_path):
 
-        if not in_path.endswith(".png")
+        if not in_path.endswith(".png"):
             return in_path
         out_path = os.path.join(self.tempdir, "optipng.png")
 

--- a/src/documents/parsers.py
+++ b/src/documents/parsers.py
@@ -64,8 +64,6 @@ class DocumentParser:
 
     def optimise_thumbnail(self, in_path):
 
-        if not in_path.endswith(".png"):
-            return in_path
         out_path = os.path.join(self.tempdir, "optipng.png")
 
         args = (self.OPTIPNG, "-o5", in_path, "-out", out_path)

--- a/src/documents/settings.py
+++ b/src/documents/settings.py
@@ -2,3 +2,4 @@
 # for exporting/importing commands
 EXPORTER_FILE_NAME = "__exported_file_name__"
 EXPORTER_THUMBNAIL_NAME = "__exported_thumbnail_name__"
+EXPORTER_THUMBNAIL_WEBP_NAME = "__exported_thumbnail_webp_name__"

--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -59,7 +59,7 @@ class FetchView(SessionOrBasicAuthMixin, DetailView):
         if self.kwargs["kind"] == "thumb":
             response = HttpResponse(
                 self._get_raw_data(self.object.thumbnail_file),
-                content_type=content_types[Document.TYPE_PNG]
+                content_type="image/webp"
             )
             cache.patch_cache_control(response, max_age=31536000, private=True)
             return response

--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -57,9 +57,16 @@ class FetchView(SessionOrBasicAuthMixin, DetailView):
         }
 
         if self.kwargs["kind"] == "thumb":
+            #response = HttpResponse(
+            #    self._get_raw_data(self.object.thumbnail_file),
+            #    content_type="image/webp"
+            #)
             response = HttpResponse(
-                self._get_raw_data(self.object.thumbnail_file),
-                content_type="image/webp"
+                "<picture>
+                    <source srcset="%s" type="image/png">
+                    <source srcset="%s" type="image/webp">
+                    <img src="%s" alt="Alt Text!">
+                </picture>" % (self.object.thumbnail_path, self.object.thumbnail_path_webp, self.object.thumbnail_path)
             )
             cache.patch_cache_control(response, max_age=31536000, private=True)
             return response

--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -60,14 +60,9 @@ class FetchView(SessionOrBasicAuthMixin, DetailView):
             #response = HttpResponse(
             #    self._get_raw_data(self.object.thumbnail_file),
             #    content_type="image/webp"
-            #)
-            response = HttpResponse(
-                "<picture>
-                    <source srcset="%s" type="image/png">
-                    <source srcset="%s" type="image/webp">
-                    <img src="%s" alt="Alt Text!">
-                </picture>" % (self.object.thumbnail_path, self.object.thumbnail_path_webp, self.object.thumbnail_path)
-            )
+            #)            
+            html_picture = '<picture><source srcset="%s type="image/png"><source srcset="%s type="image/webp"><img src="%s></picture>' % (self.object.thumbnail_path, self.object.thumbnail_path_webp, self.object.thumbnail_path)
+            response = HttpResponse(html_picture)
             cache.patch_cache_control(response, max_age=31536000, private=True)
             return response
 

--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -60,15 +60,13 @@ class FetchView(SessionOrBasicAuthMixin, DetailView):
             response = HttpResponse(
                 self._get_raw_data(self.object.thumbnail_file),
                 content_type="image/png"
-            )            
-            #html_picture = '<picture><source srcset="%s type="image/png"><source srcset="%s type="image/webp"><img src="%s></picture>' % (self.object.thumbnail_path, self.object.thumbnail_path_webp, self.object.thumbnail_path)
-            #response = HttpResponse(html_picture)
+            )
             cache.patch_cache_control(response, max_age=31536000, private=True)
             return response
 
         if self.kwargs["kind"] == "thumbwebp":
             response = HttpResponse(
-                self._get_raw_data(self.object.thumbnail_file_webp),
+                self._get_raw_data(self.object.thumbnail_webp_file),
                 content_type="image/webp"
             )
             cache.patch_cache_control(response, max_age=31536000, private=True)

--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -57,12 +57,20 @@ class FetchView(SessionOrBasicAuthMixin, DetailView):
         }
 
         if self.kwargs["kind"] == "thumb":
-            #response = HttpResponse(
-            #    self._get_raw_data(self.object.thumbnail_file),
-            #    content_type="image/webp"
-            #)            
-            html_picture = '<picture><source srcset="%s type="image/png"><source srcset="%s type="image/webp"><img src="%s></picture>' % (self.object.thumbnail_path, self.object.thumbnail_path_webp, self.object.thumbnail_path)
-            response = HttpResponse(html_picture)
+            response = HttpResponse(
+                self._get_raw_data(self.object.thumbnail_file),
+                content_type="image/png"
+            )            
+            #html_picture = '<picture><source srcset="%s type="image/png"><source srcset="%s type="image/webp"><img src="%s></picture>' % (self.object.thumbnail_path, self.object.thumbnail_path_webp, self.object.thumbnail_path)
+            #response = HttpResponse(html_picture)
+            cache.patch_cache_control(response, max_age=31536000, private=True)
+            return response
+
+        if self.kwargs["kind"] == "thumbwebp":
+            response = HttpResponse(
+                self._get_raw_data(self.object.thumbnail_file_webp),
+                content_type="image/webp"
+            )
             cache.patch_cache_control(response, max_age=31536000, private=True)
             return response
 

--- a/src/paperless/urls.py
+++ b/src/paperless/urls.py
@@ -37,7 +37,7 @@ urlpatterns = [
 
     # File downloads
     url(
-        r"^fetch/(?P<kind>doc|thumb)/(?P<pk>\d+)$",
+        r"^fetch/(?P<kind>doc|thumb|thumbwebp)/(?P<pk>\d+)$",
         FetchView.as_view(),
         name="fetch"
     ),

--- a/src/paperless_tesseract/parsers.py
+++ b/src/paperless_tesseract/parsers.py
@@ -42,7 +42,7 @@ class RasterisedDocumentParser(DocumentParser):
 
     def get_thumbnail(self):
         """
-        The thumbnail of a PDF is just a 500px wide image of the first page.
+        Thumbnail of a PDF as a 500px wide png image of the first page.
         """
 
         out_path = os.path.join(self.tempdir, "convert.png")
@@ -87,7 +87,7 @@ class RasterisedDocumentParser(DocumentParser):
 
     def get_thumbnail_webp(self):
         """
-        The thumbnail of a PDF is just a 500px wide webp image of the first page.
+        Thumbnail of a PDF as a 500px wide WebP image of the first page.
         """
 
         out_path = os.path.join(self.tempdir, "convert.webp")

--- a/src/paperless_tesseract/parsers.py
+++ b/src/paperless_tesseract/parsers.py
@@ -45,7 +45,7 @@ class RasterisedDocumentParser(DocumentParser):
         The thumbnail of a PDF is just a 500px wide image of the first page.
         """
 
-        out_path = os.path.join(self.tempdir, "convert.webp")
+        out_path = os.path.join(self.tempdir, "convert.png")
 
         # Run convert to get a decent thumbnail
         try:
@@ -83,6 +83,32 @@ class RasterisedDocumentParser(DocumentParser):
                 out_path
             )
 
+        return out_path
+
+    def get_thumbnail_webp(self):
+        """
+        The thumbnail of a PDF is just a 500px wide webp image of the first page.
+        """
+
+        out_path = os.path.join(self.tempdir, "convert.webp")
+
+        # Run convert to get a decent thumbnail
+        try:
+            run_convert(
+                self.CONVERT,
+                "-scale", "500x5000",
+                "-alpha", "remove",
+                "-strip", "-trim",
+                "{}[0]".format(self.document_path),
+                out_path
+            )
+        except ParseError:
+            # if convert fails, fall back to extracting
+            # the first PDF page as a PNG using Ghostscript
+            self.log(
+                "warning",
+                "WebP thumbnail generation with ImageMagick failed"
+            )
         return out_path
 
     def _is_ocred(self):

--- a/src/paperless_tesseract/parsers.py
+++ b/src/paperless_tesseract/parsers.py
@@ -45,7 +45,7 @@ class RasterisedDocumentParser(DocumentParser):
         The thumbnail of a PDF is just a 500px wide image of the first page.
         """
 
-        out_path = os.path.join(self.tempdir, "convert.png")
+        out_path = os.path.join(self.tempdir, "convert.webp")
 
         # Run convert to get a decent thumbnail
         try:

--- a/src/paperless_tesseract/parsers.py
+++ b/src/paperless_tesseract/parsers.py
@@ -109,6 +109,7 @@ class RasterisedDocumentParser(DocumentParser):
                 "warning",
                 "WebP thumbnail generation with ImageMagick failed"
             )
+            return
         return out_path
 
     def _is_ocred(self):


### PR DESCRIPTION
Besides django itself, the paperless webserver is often a bit sluggish due to the large thumbnails, oftentimes summing up to more than 20 MB per page.
Optipng is already used to reduce this network load a bit but uncompressed pngs are still very large and not state-of-the-art.
Google's [WebP](https://developers.google.com/speed/webp/) is a more modern image format supported by most* browsers. The big exception is Apple's Safari.
Hence in this pull-request I suggest we offer in the meantime WebP and png. Using the `<picture>` tag instead of `<img>` [the webserver can offer both with a default](https://github.com/radek-anuszewski/HTML-picture-tag-in-practice/blob/master/index.html) to the most-compatible option (here: png). In my initial experience the file size of the thumbnails is around four times smaller compared to png.

**Hints/Limitations**
- no migration implemented (yet?) -> this will not generate webp thumbnails for your existing documents. However, it should not break anything. You'll just have webp & png for your new documents and pngs for your old ones.
- not 100% happy with the quite enlarged Documents API. I'm thinking about refactoring the thumbnail logic out of the document and parser as these should be separate concerns. This could also be the chance to make this a bit more generic and possibly support a multitude of formats in the future. (E.g. Apple will probably not support WebP anytime soon as they have put their money on HEIC)

Let me know what you think! Comments (and reviews!) welcome:)