### PR TITLE
Thumbnails as jpg instead of png to improve performance

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,6 @@ RUN apk add --no-cache \
       imagemagick \
       libmagic \
       libpq \
-      optipng \
       poppler \
       python3 \
       shadow \

--- a/docs/requirements.rst
+++ b/docs/requirements.rst
@@ -12,7 +12,6 @@ should work) that has the following software installed:
 * `Imagemagick`_ version 6.7.5 or higher
 * `unpaper`_
 * `libpoppler-cpp-dev`_ PDF rendering library
-* `optipng`_
 
 .. _Python3: https://python.org/
 .. _GNU Privacy Guard: https://gnupg.org
@@ -20,7 +19,6 @@ should work) that has the following software installed:
 .. _Imagemagick: http://imagemagick.org/
 .. _unpaper: https://www.flameeyes.eu/projects/unpaper
 .. _libpoppler-cpp-dev: https://poppler.freedesktop.org/
-.. _optipng: http://optipng.sourceforge.net/
 
 Notably, you should confirm how you access your Python3 installation.  Many
 Linux distributions will install Python3 in parallel to Python2, using the

--- a/paperless.conf.example
+++ b/paperless.conf.example
@@ -252,6 +252,3 @@ PAPERLESS_EMAIL_SECRET=""
 
 # Unpaper
 #PAPERLESS_UNPAPER_BINARY=/usr/bin/unpaper
-
-# Optipng (for optimising thumbnail sizes)
-#PAPERLESS_OPTIPNG_BINARY=/usr/bin/optipng

--- a/src/documents/consumer.py
+++ b/src/documents/consumer.py
@@ -149,7 +149,7 @@ class Consumer:
         parsed_document = parser_class(doc)
 
         try:
-            thumbnail = parsed_document.get_optimised_thumbnail()
+            thumbnail = parsed_document.get_thumbnail()
             date = parsed_document.get_date()
             document = self._store(
                 parsed_document.get_text(),

--- a/src/documents/management/commands/document_exporter.py
+++ b/src/documents/management/commands/document_exporter.py
@@ -66,7 +66,7 @@ class Command(Renderable, BaseCommand):
 
             file_target = os.path.join(self.target, document.file_name)
 
-            thumbnail_name = document.file_name + "-thumbnail.png"
+            thumbnail_name = document.file_name + "-thumbnail.jpg"
             thumbnail_target = os.path.join(self.target, thumbnail_name)
 
             document_dict[EXPORTER_FILE_NAME] = document.file_name

--- a/src/documents/migrations/0012_auto_20160305_0040.py
+++ b/src/documents/migrations/0012_auto_20160305_0040.py
@@ -88,15 +88,15 @@ def move_documents_and_create_thumbnails(apps, schema_editor):
             "-scale", "500x5000",
             "-alpha", "remove",
             orig_target,
-            os.path.join(thumb_temp, "convert-%04d.png")
+            os.path.join(thumb_temp, "convert-%04d.jpg")
         )).wait()
 
-        thumb_source = os.path.join(thumb_temp, "convert-0000.png")
+        thumb_source = os.path.join(thumb_temp, "convert-0000.jpg")
         thumb_target = os.path.join(
             settings.MEDIA_ROOT,
             "documents",
             "thumbnails",
-            re.sub(r"(\d+)\.\w+(\.gpg)", "\\1.png\\2", f)
+            re.sub(r"(\d+)\.\w+(\.gpg)", "\\1.jpg\\2", f)
         )
         with open(thumb_source, "rb") as unencrypted:
             with open(thumb_target, "wb") as encrypted:

--- a/src/documents/migrations/0023_thumbnails_to_jpeg.py
+++ b/src/documents/migrations/0023_thumbnails_to_jpeg.py
@@ -27,18 +27,25 @@ class GnuPG(object):
         ).data
 
 def create_jpg_thumbnails(apps, schema_editor):
-    thumb_files = os.listdir(os.path.join(settings.MEDIA_ROOT, "documents", "thumbnails"))
+    thumb_files = os.listdir(os.path.join(settings.MEDIA_ROOT,
+                                          "documents",
+                                          "thumbnails"))
 
     for thumb in thumb_files:
-        if thumb.endswith(".jpg") or thumb.endswith(".jpg.gpg"):
+        thumb_full = os.path.join(settings.MEDIA_ROOT,
+                                  "documents",
+                                  "thumbnails",
+                                  thumb)
+
+        if thumb_full.endswith(".jpg") or thumb_full.endswith(".jpg.gpg"):
             continue
-        new_thumb = thumb[:-4] + ".jpg"
-        if thumb.endswith(".png"):            
-            convert_png_to_jpg(thumb, new_thumb)
-            os.remove(thumb)
-        if thumb.endswith(".png.gpg"):
-            thumb_decrypted = thumb[:-4]
-            with open(thumb, "rb") as encrypted:
+        new_thumb = thumb_full[:-4] + ".jpg"
+        if thumb_full.endswith(".png"):
+            convert_png_to_jpg(thumb_full, new_thumb)
+            os.remove(thumb_full)
+        if thumb_full.endswith(".png.gpg"):
+            thumb_decrypted = thumb_full[:-4]
+            with open(thumb_full, "rb") as encrypted:
                 with open(thumb_decrypted, "wb") as unencrypted:
                     unencrypted.write(GnuPG.decrypted(encrypted))
             convert_png_to_jpg(thumb_decrypted, new_thumb)
@@ -46,7 +53,7 @@ def create_jpg_thumbnails(apps, schema_editor):
             with open(new_thumb, "rb") as unencrypted:
                 with open(new_thumb_encrypted, "wb") as encrypted:
                     encrypted.write(GnuPG.decrypted(unencrypted))
-            os.remove(thumb)
+            os.remove(thumb_full)
             os.remove(thumb_decrypted)
             os.remove(new_thumb)
 

--- a/src/documents/migrations/0023_thumbnails_to_jpeg.py
+++ b/src/documents/migrations/0023_thumbnails_to_jpeg.py
@@ -1,0 +1,72 @@
+import os
+import subprocess
+import gnupg
+
+from django.conf import settings
+from django.db import migrations, models
+
+class GnuPG(object):
+    """
+    A handy singleton to use when handling encrypted files.
+    """
+
+    gpg = gnupg.GPG(gnupghome=settings.GNUPG_HOME)
+
+    @classmethod
+    def decrypted(cls, file_handle):
+        return cls.gpg.decrypt_file(
+            file_handle, passphrase=settings.PASSPHRASE).data
+
+    @classmethod
+    def encrypted(cls, file_handle):
+        return cls.gpg.encrypt_file(
+            file_handle,
+            recipients=None,
+            passphrase=settings.PASSPHRASE,
+            symmetric=True
+        ).data
+
+def create_jpg_thumbnails(apps, schema_editor):
+    thumb_files = os.listdir(os.path.join(settings.MEDIA_ROOT, "documents", "thumbnails"))
+
+    for thumb in thumb_files:
+        if thumb.endswith(".jpg") or thumb.endswith(".jpg.gpg"):
+            continue
+        new_thumb = thumb[:-4] + ".jpg"
+        if thumb.endswith(".png"):            
+            convert_png_to_jpg(thumb, new_thumb)
+            os.remove(thumb)
+        if thumb.endswith(".png.gpg"):
+            thumb_decrypted = thumb[:-4]
+            with open(thumb, "rb") as encrypted:
+                with open(thumb_decrypted, "wb") as unencrypted:
+                    unencrypted.write(GnuPG.decrypted(encrypted))
+            convert_png_to_jpg(thumb_decrypted, new_thumb)
+            new_thumb_encrypted = new_thumb + ".gpg"
+            with open(new_thumb, "rb") as unencrypted:
+                with open(new_thumb_encrypted, "wb") as encrypted:
+                    encrypted.write(GnuPG.decrypted(unencrypted))
+            os.remove(thumb)
+            os.remove(thumb_decrypted)
+            os.remove(new_thumb)
+
+
+def convert_png_to_jpg(png_path, jpg_path):
+    subprocess.Popen((
+        settings.CONVERT_BINARY,
+        "-scale", "500x5000",
+        "-alpha", "remove",
+        "-strip", "-trim",
+        png_path,
+        jpg_path
+    )).wait()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('documents', '0022_auto_20181007_1420'),
+    ]
+
+    operations = [
+        migrations.RunPython(create_jpg_thumbnails),
+    ]

--- a/src/documents/migrations/0023_thumbnails_to_jpeg.py
+++ b/src/documents/migrations/0023_thumbnails_to_jpeg.py
@@ -54,9 +54,9 @@ def create_jpg_thumbnails(apps, schema_editor):
             with open(new_thumb, "rb") as unencrypted:
                 with open(new_thumb_encrypted, "wb") as encrypted:
                     encrypted.write(GnuPG.encrypted(unencrypted))
-            #os.remove(thumb_full)
-            #os.remove(thumb_decrypted)
-            #os.remove(new_thumb)
+            os.remove(thumb_full)
+            os.remove(thumb_decrypted)
+            os.remove(new_thumb)
 
 
 def convert_png_to_jpg(png_path, jpg_path):

--- a/src/documents/migrations/0023_thumbnails_to_jpeg.py
+++ b/src/documents/migrations/0023_thumbnails_to_jpeg.py
@@ -39,12 +39,13 @@ def create_jpg_thumbnails(apps, schema_editor):
 
         if thumb_full.endswith(".jpg") or thumb_full.endswith(".jpg.gpg"):
             continue
-        new_thumb = thumb_full[:-4] + ".jpg"
         if thumb_full.endswith(".png"):
+            new_thumb = thumb_full[:-4] + ".jpg"
             convert_png_to_jpg(thumb_full, new_thumb)
             os.remove(thumb_full)
         if thumb_full.endswith(".png.gpg"):
             thumb_decrypted = thumb_full[:-4]
+            new_thumb = thumb_decrypted[:-4] + ".jpg"
             with open(thumb_full, "rb") as encrypted:
                 with open(thumb_decrypted, "wb") as unencrypted:
                     unencrypted.write(GnuPG.decrypted(encrypted))
@@ -52,10 +53,10 @@ def create_jpg_thumbnails(apps, schema_editor):
             new_thumb_encrypted = new_thumb + ".gpg"
             with open(new_thumb, "rb") as unencrypted:
                 with open(new_thumb_encrypted, "wb") as encrypted:
-                    encrypted.write(GnuPG.decrypted(unencrypted))
-            os.remove(thumb_full)
-            os.remove(thumb_decrypted)
-            os.remove(new_thumb)
+                    encrypted.write(GnuPG.encrypted(unencrypted))
+            #os.remove(thumb_full)
+            #os.remove(thumb_decrypted)
+            #os.remove(new_thumb)
 
 
 def convert_png_to_jpg(png_path, jpg_path):

--- a/src/documents/models.py
+++ b/src/documents/models.py
@@ -295,7 +295,7 @@ class Document(models.Model):
     @property
     def thumbnail_path(self):
 
-        file_name = "{:07}.png".format(self.pk)
+        file_name = "{:07}.jpg".format(self.pk)
         if self.storage_type == self.STORAGE_TYPE_GPG:
             file_name += ".gpg"
 

--- a/src/documents/parsers.py
+++ b/src/documents/parsers.py
@@ -56,19 +56,6 @@ class DocumentParser:
         """
         raise NotImplementedError()
 
-    def optimise_thumbnail(self, in_path):
-
-        out_path = os.path.join(self.tempdir, "optipng.png")
-
-        args = (self.OPTIPNG, "-o5", in_path, "-out", out_path)
-        if not subprocess.Popen(args).wait() == 0:
-            raise ParseError("Optipng failed at {}".format(args))
-
-        return out_path
-
-    def get_optimised_thumbnail(self):
-        return self.get_thumbnail()
-
     def get_text(self):
         """
         Returns the text from the document and only the text.

--- a/src/documents/parsers.py
+++ b/src/documents/parsers.py
@@ -67,7 +67,7 @@ class DocumentParser:
         return out_path
 
     def get_optimised_thumbnail(self):
-        return self.optimise_thumbnail(self.get_thumbnail())
+        return self.get_thumbnail()
 
     def get_text(self):
         """

--- a/src/documents/parsers.py
+++ b/src/documents/parsers.py
@@ -42,7 +42,6 @@ class DocumentParser:
     SCRATCH = settings.SCRATCH_DIR
     DATE_ORDER = settings.DATE_ORDER
     FILENAME_DATE_ORDER = settings.FILENAME_DATE_ORDER
-    OPTIPNG = settings.OPTIPNG_BINARY
 
     def __init__(self, path):
         self.document_path = path

--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -59,7 +59,7 @@ class FetchView(SessionOrBasicAuthMixin, DetailView):
         if self.kwargs["kind"] == "thumb":
             response = HttpResponse(
                 self._get_raw_data(self.object.thumbnail_file),
-                content_type=content_types[Document.TYPE_PNG]
+                content_type=content_types[Document.TYPE_JPG]
             )
             cache.patch_cache_control(response, max_age=31536000, private=True)
             return response

--- a/src/paperless/checks.py
+++ b/src/paperless/checks.py
@@ -78,7 +78,6 @@ def binaries_check(app_configs, **kwargs):
 
     binaries = (
         settings.CONVERT_BINARY,
-        settings.OPTIPNG_BINARY,
         settings.UNPAPER_BINARY,
         "tesseract"
     )

--- a/src/paperless/settings.py
+++ b/src/paperless/settings.py
@@ -266,9 +266,6 @@ CONVERT_DENSITY = os.getenv("PAPERLESS_CONVERT_DENSITY")
 # Ghostscript
 GS_BINARY = os.getenv("PAPERLESS_GS_BINARY", "gs")
 
-# OptiPNG
-OPTIPNG_BINARY = os.getenv("PAPERLESS_OPTIPNG_BINARY", "optipng")
-
 # Unpaper
 UNPAPER_BINARY = os.getenv("PAPERLESS_UNPAPER_BINARY", "unpaper")
 

--- a/src/paperless_tesseract/parsers.py
+++ b/src/paperless_tesseract/parsers.py
@@ -45,7 +45,7 @@ class RasterisedDocumentParser(DocumentParser):
         The thumbnail of a PDF is just a 500px wide image of the first page.
         """
 
-        out_path = os.path.join(self.tempdir, "convert.png")
+        out_path = os.path.join(self.tempdir, "convert.jpg")
 
         # Run convert to get a decent thumbnail
         try:
@@ -65,7 +65,7 @@ class RasterisedDocumentParser(DocumentParser):
                 "Thumbnail generation with ImageMagick failed, "
                 "falling back to Ghostscript."
             )
-            gs_out_path = os.path.join(self.tempdir, "gs_out.png")
+            gs_out_path = os.path.join(self.tempdir, "gs_out.jpg")
             cmd = [self.GHOSTSCRIPT,
                    "-q",
                    "-sDEVICE=pngalpha",

--- a/src/paperless_tesseract/parsers.py
+++ b/src/paperless_tesseract/parsers.py
@@ -59,7 +59,7 @@ class RasterisedDocumentParser(DocumentParser):
             )
         except ParseError:
             # if convert fails, fall back to extracting
-            # the first PDF page as a PNG using Ghostscript
+            # the first PDF page as a jpg using Ghostscript
             self.log(
                 "warning",
                 "Thumbnail generation with ImageMagick failed, "

--- a/src/paperless_text/parsers.py
+++ b/src/paperless_text/parsers.py
@@ -32,7 +32,7 @@ class TextDocumentParser(DocumentParser):
         text_color = "black"  # text color
         psize = [500, 647]  # icon size
         n_lines = 50  # number of lines to show
-        out_path = os.path.join(self.tempdir, "convert.png")
+        out_path = os.path.join(self.tempdir, "convert.jpg")
 
         temp_bg = os.path.join(self.tempdir, "bg.png")
         temp_txlayer = os.path.join(self.tempdir, "tx.png")


### PR DESCRIPTION
As discussed in https://github.com/the-paperless-project/paperless/pull/559 this PR suggests to move the thumbnails from pngs to jpgs.

- file sizes are ~15-50% smaller
- jpg is widely adopted and compatible (in contrast to WebP as in #559 
- migration script to move over existing installs from png to jpg
- tested on Docker setup with and without enabled encryption

Let me know what you think!