### PR TITLE
Upgrade docker base image to alpine v3.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM alpine:3.10
 
 LABEL maintainer="The Paperless Project https://github.com/the-paperless-project/paperless" \
       contributors="Guy Addadi <addadi@gmail.com>, Pit Kleyersburg <pitkley@googlemail.com>, \


### PR DESCRIPTION
Alpine's[ current stable release](https://wiki.alpinelinux.org/wiki/Alpine_Linux:Releases) is v3.10.
Among other things, it updates the imagemagick and ghostscript version which fixes some "convert failed" errors on my install.