### PR TITLE
Gunicorn webserver in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,10 @@ LABEL maintainer="The Paperless Project https://github.com/the-paperless-project
       contributors="Guy Addadi <addadi@gmail.com>, Pit Kleyersburg <pitkley@googlemail.com>, \
         Sven Fischer <git-dev@linux4tw.de>"
 
-# Copy Pipfiles file and init script
+# Copy Pipfiles file, init script and gunicorn.conf
 COPY Pipfile* /usr/src/paperless/
 COPY scripts/docker-entrypoint.sh /sbin/docker-entrypoint.sh
+COPY scripts/gunicorn.conf /usr/src/paperless/
 
 # Set export and consumption directories
 ENV PAPERLESS_EXPORT_DIR=/export \

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -27,7 +27,7 @@ services:
         # value with nothing.
         environment:
             - PAPERLESS_OCR_LANGUAGES=
-        command: ["runserver", "--insecure", "--noreload", "0.0.0.0:8000"]
+        command: ["gunicorn"]
 
     consumer:
         build: ./

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -27,7 +27,7 @@ services:
         # value with nothing.
         environment:
             - PAPERLESS_OCR_LANGUAGES=
-        command: ["gunicorn"]
+        command: ["gunicorn", "-b", "0.0.0.0:8000"]
 
     consumer:
         build: ./

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -99,7 +99,12 @@ if [[ "$1" != "/"* ]]; then
         install_languages "$PAPERLESS_OCR_LANGUAGES"
     fi
 
-    exec sudo -HEu paperless "/usr/src/paperless/src/manage.py" "$@"
+    if [[ "$1" = "gunicorn" ]]; then
+        cd /usr/src/paperless/src/ && \
+            exec sudo -HEu paperless /usr/bin/gunicorn -c gunicorn.conf paperless.wsgi
+    else
+        exec sudo -HEu paperless "/usr/src/paperless/src/manage.py" "$@"
+    fi
 fi
 
 exec "$@"

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -100,8 +100,9 @@ if [[ "$1" != "/"* ]]; then
     fi
 
     if [[ "$1" = "gunicorn" ]]; then
+        shift
         cd /usr/src/paperless/src/ && \
-            exec sudo -HEu paperless /usr/bin/gunicorn -c /usr/src/paperless/gunicorn.conf paperless.wsgi
+            exec sudo -HEu paperless /usr/bin/gunicorn -c /usr/src/paperless/gunicorn.conf "$@" paperless.wsgi
     else
         exec sudo -HEu paperless "/usr/src/paperless/src/manage.py" "$@"
     fi

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -101,7 +101,7 @@ if [[ "$1" != "/"* ]]; then
 
     if [[ "$1" = "gunicorn" ]]; then
         cd /usr/src/paperless/src/ && \
-            exec sudo -HEu paperless /usr/bin/gunicorn -c gunicorn.conf paperless.wsgi
+            exec sudo -HEu paperless /usr/bin/gunicorn -c /usr/src/paperless/gunicorn.conf paperless.wsgi
     else
         exec sudo -HEu paperless "/usr/src/paperless/src/manage.py" "$@"
     fi


### PR DESCRIPTION
In #552 we prepared django to serve the static files in a more efficient manner using whitenoise.
Next step: using [gunicorn](https://gunicorn.org/) to spin up a few more workers and get that webserver flying:)

I used the existing gunicorn config file, however I had to change the bind-ip to 0.0.0.0 to get it working. Does anybody know if that's really necessary?

Reviews, comments etc. are always welcome!