### PR TITLE
Escape user-provided text passed to regex

### DIFF
--- a/src/documents/models.py
+++ b/src/documents/models.py
@@ -98,20 +98,20 @@ class MatchingModel(models.Model):
         if self.matching_algorithm == self.MATCH_ALL:
             for word in self._split_match():
                 search_result = re.search(
-                    r"\b{}\b".format(word), text, **search_kwargs)
+                    r"\b{}\b".format(re.escape(word)), text, **search_kwargs)
                 if not search_result:
                     return False
             return True
 
         if self.matching_algorithm == self.MATCH_ANY:
             for word in self._split_match():
-                if re.search(r"\b{}\b".format(word), text, **search_kwargs):
+                if re.search(r"\b{}\b".format(re.escape(word)), text, **search_kwargs):
                     return True
             return False
 
         if self.matching_algorithm == self.MATCH_LITERAL:
             return bool(re.search(
-                r"\b{}\b".format(self.match), text, **search_kwargs))
+                r"\b{}\b".format(re.escape(self.match)), text, **search_kwargs))
 
         if self.matching_algorithm == self.MATCH_REGEX:
             return bool(re.search(


### PR DESCRIPTION
Rather than using the user/document-provided values directly, we instead escape them to use them verbatim.

This fixes issue 568.

---

I only checked the `models.py` file for occurrences of unescaped regex-"injections". There might be more across the project.