### PR TITLE
Add PDF preview next to edit form

### DIFF
--- a/src/documents/templates/admin/documents/document/change_form.html
+++ b/src/documents/templates/admin/documents/document/change_form.html
@@ -3,6 +3,10 @@
 {% block content %}
 
 {{ block.super }}
+<div class="side-preview">
+  <h2>Preview</h2>
+  <object data="/fetch/preview/{{object_id}}"></object>
+</div>
 
 {% if next_object %}
 	<script type="text/javascript">//<![CDATA[
@@ -16,6 +20,37 @@
 {% endif %}
 
 {% endblock content %}
+
+{% block extrastyle %}
+{{ block.super }}
+<style>
+.side-preview {
+    width: 100%;
+    height: 800px;
+    clear: both;
+}
+
+.side-preview object {
+    height: 100%;
+    width: 100%;
+}
+
+@media screen and (min-width: 1500px) {
+    #content-main {
+        width: 50%;
+    }
+    #footer {
+        padding: 0;
+    }
+    .side-preview {
+        float: right;
+        width: 40%;
+        height: 80vh;
+        clear: none;
+    }
+}
+</style>
+{% endblock %}
 
 {% block footer %}
 

--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -69,7 +69,10 @@ class FetchView(SessionOrBasicAuthMixin, DetailView):
             content_type=content_types[self.object.file_type]
         )
 
-        DISPOSITION = 'inline' if settings.INLINE_DOC else 'attachment'
+        DISPOSITION = (
+            'inline' if settings.INLINE_DOC or self.kwargs["kind"] == 'preview'
+            else 'attachment'
+        )
 
         response["Content-Disposition"] = '{}; filename="{}"'.format(
             DISPOSITION, self.object.file_name)

--- a/src/paperless/urls.py
+++ b/src/paperless/urls.py
@@ -37,7 +37,7 @@ urlpatterns = [
 
     # File downloads
     url(
-        r"^fetch/(?P<kind>doc|thumb)/(?P<pk>\d+)$",
+        r"^fetch/(?P<kind>doc|thumb|preview)/(?P<pk>\d+)$",
         FetchView.as_view(),
         name="fetch"
     ),


### PR DESCRIPTION
This adds a simple PDF preview next to the edit form. Adding the CSS to the page footer is a bit ugly. If anyone with better knowledge of Django knows of a cleaner way to do this, please let me know.

On a large enough screen, it looks like this:
![image](https://user-images.githubusercontent.com/598790/71755515-39023800-2e8b-11ea-9a9a-942f2477ab7f.png)

If there is not enough space, the preview will be shown below the form:
![image](https://user-images.githubusercontent.com/598790/71755796-c003e000-2e8c-11ea-947b-5d4ae30c12d2.png)



Closes: #596