### PR TITLE
Allow non-unique GIDs

### DIFF
--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -10,7 +10,7 @@ map_uidgid() {
     if [[ ${USERMAP_NEW_UID} != "${USERMAP_ORIG_UID}" || ${USERMAP_NEW_GID} != "${USERMAP_ORIG_GID}" ]]; then
         echo "Mapping UID and GID for paperless:paperless to $USERMAP_NEW_UID:$USERMAP_NEW_GID"
         usermod -u "${USERMAP_NEW_UID}" paperless
-        groupmod -g "${USERMAP_NEW_GID}" paperless
+        groupmod -o -g "${USERMAP_NEW_GID}" paperless
     fi
 }
 


### PR DESCRIPTION
Need to allow non-unique group ids, so paperless can map to an existing GID.

The comment says the map_uidgid() function came from docker-gitlab, the same fix was applied there too:
  https://github.com/sameersbn/docker-gitlab/commit/c80bd876628d0c04f8ef2a3ffb46fe899bf63d23