### PR TITLE
Fix warnings in bash code blocks

### DIFF
--- a/docs/utilities.rst
+++ b/docs/utilities.rst
@@ -239,10 +239,10 @@ Basic Syntax
 
 Again we'll use the ``manage.py`` script, passing ``change_storage_type``:
 
-.. code:: bash
+.. code:: console
 
     $ /path/to/paperless/src/manage.py change_storage_type --help
-		usage: manage.py change_storage_type [-h] [--version] [-v {0,1,2,3}]
+    usage: manage.py change_storage_type [-h] [--version] [-v {0,1,2,3}]
                                      [--settings SETTINGS]
                                      [--pythonpath PYTHONPATH] [--traceback]
                                      [--no-color] [--passphrase PASSPHRASE]


### PR DESCRIPTION
### Summary 

* Fixes warning generating docs: `WARNING: Could not lex literal_block as "bash". Highlighting skipped`.

### Addressed Issues

* See https://github.com/sphinx-doc/sphinx/issues/4098

### Expected Behaviour 

* `$ sphinx-build -b html ../docs ../docs/_build -W` builds documentation successfully

### Actual Behaviour 

* Building documentation fails with error
* This issue also occurs in the Travis build pipeline

```bash
(paperless) user:paperless/src$ sphinx-build -b html ../docs ../docs/_build -W
Running Sphinx v2.3.1
loading intersphinx inventory from http://docs.python.org/objects.inv...
intersphinx inventory has moved: http://docs.python.org/objects.inv -> https://docs.python.org/3/objects.inv
building [mo]: targets for 0 po files that are out of date
building [html]: targets for 15 source files that are out of date
updating environment: [new config] 15 added, 0 changed, 0 removed
reading sources... [100%] utilities                                                                                       
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
writing output... [100%] utilities                                                                                        

Warning, treated as error:
/paperless/docs/utilities.rst:242:Could not lex literal_block as "bash". Highlighting skipped.
```

### Conducted Tests after Patch

```bash
$ sphinx-build -b html ../docs ../docs/_build -W
$ firefox docs/_build/index.html
```
![paperless-docs-utilities](https://user-images.githubusercontent.com/5375334/72195437-93af0d00-3412-11ea-81bc-6cfcd205ecd5.png)

:arrow_right: still looks good with patch
