### PR TITLE
Add timezone variable to Docker containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN apk add --no-cache \
       shadow \
       sudo \
       tesseract-ocr \
+			tzdata \
       unpaper && \
     apk add --no-cache --virtual .build-dependencies \
       g++ \

--- a/docker-compose.env.example
+++ b/docker-compose.env.example
@@ -11,6 +11,8 @@
 # ...are all explained in that file but can be defined here, since the Docker
 # installation doesn't make use of paperless.conf.
 
+# Use this variable to set a timezone for the Paperless Docker containers. If not specified, defaults to UTC.
+# TZ=America/Los_Angeles
 
 # Additional languages to install for text recognition.  Note that this is
 # different from PAPERLESS_OCR_LANGUAGE (default=eng), which defines the


### PR DESCRIPTION
This pull request allows the timezone used in the Docker containers to be set via environment variable. It installs the `tzdata` package inside the containers and adds a `TZ` variable example to `docker-compose.env.example`. 

