### PR TITLE
Update unpaper website link.

### DIFF
--- a/README-de.md
+++ b/README-de.md
@@ -42,7 +42,7 @@ Dies alles ist eine wirklich ziemlich einfache, glänzende und benutzerfreundlic
 
 * [ImageMagick](http://imagemagick.org/) wandelt Bilder zwischen Farbe und Graustufen um.
 * [Tesseract](https://github.com/tesseract-ocr) erledigt die Buchstabenerkennung.
-* [Unpaper](https://www.flameeyes.eu/projects/unpaper) bereinigt und begradigt das eingescannte Bild.
+* [Unpaper](https://github.com/unpaper/unpaper) bereinigt und begradigt das eingescannte Bild.
 * [GNU Privacy Guard](https://gnupg.org/) wird als Verschlüsselungsbackend genutzt.
 * [Python 3](https://python.org/) ist die Sprache des Projekts.
   * [Pillow](https://pypi.python.org/pypi/pillowfight/) lädt die Bilddaten als Python-Objekt, um sie mit PyOCR zu verwenden.

--- a/README-el.md
+++ b/README-el.md
@@ -41,7 +41,7 @@
 
 * [ImageMagick](http://imagemagick.org/) μετατρέπει τις εικόνες σε έγχρωμες και ασπρόμαυρες.
 * [Tesseract](https://github.com/tesseract-ocr) κάνει την αναγνώρηση των χαρακτήρων.
-* [Unpaper](https://www.flameeyes.eu/projects/unpaper) despeckles and deskews the scanned image.
+* [Unpaper](https://github.com/unpaper/unpaper) despeckles and deskews the scanned image.
 * [GNU Privacy Guard](https://gnupg.org/) χρησιμοποιείται για κρυπτογράφηση στο backend.
 * [Python 3](https://python.org/) είναι η γλώσσα του project.
   * [Pillow](https://pypi.python.org/pypi/pillowfight/) Φορτώνει την εικόνα σαν αντικείμενο στην python και μπορεί να χρησιμοποιηθεί με PyOCR

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ This is all really a quite simple, shiny, user-friendly wrapper around some very
 
 * [ImageMagick](http://imagemagick.org/) converts the images between colour and greyscale.
 * [Tesseract](https://github.com/tesseract-ocr) does the character recognition.
-* [Unpaper](https://www.flameeyes.eu/projects/unpaper) despeckles and deskews the scanned image.
+* [Unpaper](https://github.com/unpaper/unpaper) despeckles and deskews the scanned image.
 * [GNU Privacy Guard](https://gnupg.org/) is used as the encryption backend.
 * [Python 3](https://python.org/) is the language of the project.
   * [Pillow](https://pypi.python.org/pypi/pillowfight/) loads the image data as a python object to be used with PyOCR.

--- a/docs/requirements.rst
+++ b/docs/requirements.rst
@@ -18,7 +18,7 @@ should work) that has the following software installed:
 .. _GNU Privacy Guard: https://gnupg.org
 .. _Tesseract: https://github.com/tesseract-ocr
 .. _Imagemagick: http://imagemagick.org/
-.. _unpaper: https://www.flameeyes.eu/projects/unpaper
+.. _unpaper: https://github.com/unpaper/unpaper
 .. _libpoppler-cpp-dev: https://poppler.freedesktop.org/
 .. _optipng: http://optipng.sourceforge.net/
 


### PR DESCRIPTION
flameeyes.eu is a legacy domain, and even flameeyes.com/p/unpaper is a
temporary link, but it's one that can be changed to point at whichever new
home unpaper will get in the future.

Note: Unpaper is not actively maintained, and I'd rather look for someone
to take it over.