### PR TITLE
Prevent Paperless crash when consume folder is unavailable

### DIFF
--- a/src/documents/consumer.py
+++ b/src/documents/consumer.py
@@ -87,20 +87,27 @@ class Consumer:
         """
         ignored_files = []
         files = []
-        for entry in os.scandir(self.consume):
-            if entry.is_file():
-                file = (entry.path, entry.stat().st_mtime)
-                if file in self._ignore:
-                    ignored_files.append(file)
+        try:
+            for entry in os.scandir(self.consume):
+                if entry.is_file():
+                    file = (entry.path, entry.stat().st_mtime)
+                    if file in self._ignore:
+                        ignored_files.append(file)
+                    else:
+                        files.append(file)
                 else:
-                    files.append(file)
-            else:
-                self.logger.warning(
-                    "Skipping %s as it is not a file",
-                    entry.path
-                )
+                    self.logger.warning(
+                        "Skipping %s as it is not a file",
+                        entry.path
+                    )
 
-        if not files:
+            if not files:
+                return
+        
+        except OSError:
+            self.logger.warning(
+                "Consume folder is unavailable."
+            )
             return
 
         # Set _ignore to only include files that still exist.


### PR DESCRIPTION
When the consume folder for paperless is on a network drive, and that location is (temporary) unavailable, then the consumer in docker crashes. The only way to resume is by manually restarting the container.

This small addition catches the error and prevents the consumer from crashing. The cosumer resumes it's duties after the location is available again.