### PR TITLE
Increase gunicorn workers from 1 to 4

### DIFF
--- a/scripts/gunicorn.conf
+++ b/scripts/gunicorn.conf
@@ -1,6 +1,6 @@
 bind = '127.0.0.1:8000'
 backlog = 2048
-workers = 4
+workers = 3
 worker_class = 'sync'
 worker_connections = 1000
 timeout = 20

--- a/scripts/gunicorn.conf
+++ b/scripts/gunicorn.conf
@@ -1,6 +1,6 @@
 bind = '127.0.0.1:8000'
 backlog = 2048
-workers = 1
+workers = 4
 worker_class = 'sync'
 worker_connections = 1000
 timeout = 20


### PR DESCRIPTION
Having only 1 gunicorn worker results in extremely slow web UI load speed, raising it to 4 should improve performance significantly without overwhelming low end server environments. 

See [https://docs.gunicorn.org/en/stable/design.html#how-many-workers](https://docs.gunicorn.org/en/stable/design.html#how-many-workers) for more details

This resolves issue #613.
