### PR TITLE
Add link to Paperless App to Related Projects

### DIFF
--- a/README-de.md
+++ b/README-de.md
@@ -62,6 +62,7 @@ Ich entwickle keine neuen Funktionen mehr für Paperless, weil es genau das tut,
 
 Paperless gibt es bereits seit einer Weile und Leute haben damit angefangen, Sachen rund um Paperless zu entwickeln. Wenn du einer dieser Menschen bist, kannst du dein Projekt zu dieser Liste hinzufügen:
 
+* [Paperless App](https://github.com/bauerj/paperless_app): Eine Android/iOS-App für Paperless.
 * [Paperless Desktop](https://github.com/thomasbrueggemann/paperless-desktop): Eine Desktop-Oberfläche für deine Paperless-Installation. Läuft auf Mac, Linux und Windows.
 * [ansible-role-paperless](https://github.com/ovv/ansible-role-paperless): Eine einfache Möglichkeit, Paperless via Ansible laufen zu lassen.
 * [paperless-cli](https://github.com/stgarf/paperless-cli): Ein golang Kommandozeilenprogramm, welches mit Paperless interagiert.

--- a/README-el.md
+++ b/README-el.md
@@ -59,6 +59,7 @@
 
 Το Paperless υπάρχει εδώ και κάποιο καιρό και άνθρωποι έχουν αρχίσει να φτιάχνουν πράγματα γύρω από αυτό. Αν είσαι ένας από αυτούς τους ανθρώπους, μπορούμε να βάλουμε το project σου σε αυτήν την λίστα:
 
+* [Paperless App](https://github.com/bauerj/paperless_app): Μια εφαρμογή Android / iOS για Paperless.
 * [Paperless Desktop](https://github.com/thomasbrueggemann/paperless-desktop): Μια desktop εφαρμογή για εγκατάσταση του Paperless.  Τρέχει σε Mac, Linux, και Windows.
 * [ansible-role-paperless](https://github.com/ovv/ansible-role-paperless): Ένας εύκολο τρόπος για να τρέχει το Paperless μέσω Ansible.
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ I am no longer doing new development on Paperless as it does exactly what I need
 
 Paperless has been around a while now, and people are starting to build stuff on top of it.  If you're one of those people, we can add your project to this list:
 
+* [Paperless App](https://github.com/bauerj/paperless_app): An Android/iOS app for Paperless.
 * [Paperless Desktop](https://github.com/thomasbrueggemann/paperless-desktop): A desktop UI for your Paperless installation.  Runs on Mac, Linux, and Windows.
 * [ansible-role-paperless](https://github.com/ovv/ansible-role-paperless): An easy way to get Paperless running via Ansible.
 * [paperless-cli](https://github.com/stgarf/paperless-cli): A golang command line binary to interact with a Paperless instance.


### PR DESCRIPTION
Hey,

I'm developing a native Android/iOS frontend for Paperless using Flutter at https://github.com/bauerj/paperless_app.

I didn't have much users testing it yet so I would be glad if anyone could give any feedback. It has limited functionality (filter, search, open PDF) but I plan to extend it with more features like an offline mode.

@danielquinn Do you think it would be a good idea to move this project to the @the-paperless-project organisation? I think it could improve visibility and open source contributions.