### PR TITLE
Fix warning in models.py

### DIFF
--- a/src/documents/models.py
+++ b/src/documents/models.py
@@ -336,10 +336,10 @@ class Document(models.Model):
             # Find delimiter
             delimiter = t.name.find('_')
 
-            if delimiter is -1:
+            if delimiter == -1:
                 delimiter = t.name.find('-')
 
-            if delimiter is -1:
+            if delimiter == -1:
                 continue
 
             key = t.name[:delimiter]


### PR DESCRIPTION
When I ran `docker-compose run --rm webserver createsuperuser` I got the following warning:

```
/usr/src/paperless/src/documents/models.py:339: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if delimiter is -1:
/usr/src/paperless/src/documents/models.py:342: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if delimiter is -1:
```