### PR TITLE
Preserve file metadata when exporting

### DIFF
--- a/src/documents/management/commands/document_exporter.py
+++ b/src/documents/management/commands/document_exporter.py
@@ -87,8 +87,8 @@ class Command(Renderable, BaseCommand):
 
             else:
 
-                shutil.copy(document.source_path, file_target)
-                shutil.copy(document.thumbnail_path, thumbnail_target)
+                shutil.copy2(document.source_path, file_target)
+                shutil.copy2(document.thumbnail_path, thumbnail_target)
 
         manifest += json.loads(
             serializers.serialize("json", Correspondent.objects.all()))


### PR DESCRIPTION
* Use [`copy2`](https://docs.python.org/2/library/shutil.html#shutil.copy2) instead of `copy` when exporting documents. This preserves documents metadata

* Useful when the export dir is used to `rsync` files to a remote host for offsite backups. The function `copy2` makes sure the modification date does not change when exporting on a regular basis. Otherwise, `rsync` copies all files to the target even if they already exist on the remote. One can work around this behavior with `--ignore-existing`,  but I think copying metadata backups with the export functionality is important.