### PR TITLE
Added missing dependency to fix failing lxc install

### DIFF
--- a/docs/examples/lxc/lxc-install.sh
+++ b/docs/examples/lxc/lxc-install.sh
@@ -107,7 +107,7 @@ fi
 su -c "cd /home/paperless ; git clone https://github.com/the-paperless-project/paperless" paperless
 
 # Install Pip Requirements
-apt-get -y install python3-pip python3-venv
+apt-get -y install python3-pip python3-venv postgresql-devel
 cd /home/paperless/paperless
 pip3 install -r requirements.txt
 

--- a/docs/examples/lxc/lxc-install.sh
+++ b/docs/examples/lxc/lxc-install.sh
@@ -107,7 +107,7 @@ fi
 su -c "cd /home/paperless ; git clone https://github.com/the-paperless-project/paperless" paperless
 
 # Install Pip Requirements
-apt-get -y install python3-pip python3-venv postgresql-devel
+apt-get -y install python3-pip python3-venv libpq-dev
 cd /home/paperless/paperless
 pip3 install -r requirements.txt
 


### PR DESCRIPTION
While using the lxc install script on a ubuntu lxc container running on proxmox, I encountered the below error while pip install was trying to install psycogp2 
<img width="1083" alt="Screenshot 2020-07-18 at 4 41 26 PM" src="https://user-images.githubusercontent.com/11258286/87851346-87ea5900-c915-11ea-84cc-c6cf0b11509e.png">
The package containing the missing dependency (pg_config) needs to be installed beforehand on the system, this PR fixes the issue