### PR TITLE
Add WSGIPassAuthorization On to wsgi to support basic auth

### DIFF
--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -342,6 +342,7 @@ and mod_wsgi, with a Paperless installation in ``/home/paperless/``:
         WSGIScriptAlias / /home/paperless/paperless/src/paperless/wsgi.py
         WSGIDaemonProcess example.com user=paperless group=paperless threads=5 python-path=/home/paperless/paperless/src:/home/paperless/.env/lib/python3.6/site-packages
         WSGIProcessGroup example.com
+				WSGIPassAuthorization On
 
         <Directory /home/paperless/paperless/src/paperless>
             <Files wsgi.py>


### PR DESCRIPTION
Basic auth is used by the paperless api. In order to use basic auth with wsgi this directive is required:

`WSGIPassAuthorization On`
https://www.django-rest-framework.org/api-guide/authentication/#setting-the-authentication-scheme