### PR TITLE
Disable DjangoQL 0.14 advanced search syntax by default.

### DIFF
--- a/src/documents/admin.py
+++ b/src/documents/admin.py
@@ -196,6 +196,8 @@ class DocumentAdmin(DjangoQLSearchMixin, CommonAdmin):
 
     date_hierarchy = "created"
 
+    djangoql_completion_enabled_by_default = False
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.document_queue = []


### PR DESCRIPTION
DjangoQL 0.14 enables advanced search/completion by default. This patch
disables it again, so paperless behaves the same regardless of the
version used.

See
- https://github.com/ivelum/djangoql/blob/master/CHANGES.rst#0140
- https://github.com/ivelum/djangoql#using-djangoql-with-the-standard-django-admin-search

When using DjangoQL 0.13, this is simply a NOOP.