### PR TITLE
"Encrpytion" to "Encryption" spelling fix

### DIFF
--- a/docs/utilities.rst
+++ b/docs/utilities.rst
@@ -226,7 +226,7 @@ This is the similar command to run after adding or changing a correspondent.
 
 .. _utilities-encyption:
 
-Enabling Encrpytion
+Enabling Encryption
 -------------------
 
 Let's say you've imported a few documents to play around with paperless and now


### PR DESCRIPTION
Pretty self-explanatory spelling mistake that I came across.